### PR TITLE
Feat/client manual control

### DIFF
--- a/src/main/java/com/example/backendmainserver/auth/presentation/AdminAuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/com/example/backendmainserver/auth/presentation/AdminAuthenticationPrincipalArgumentResolver.java
@@ -23,7 +23,7 @@ public class AdminAuthenticationPrincipalArgumentResolver implements HandlerMeth
     private final UserService userService;
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+        return parameter.hasParameterAnnotation(AdminAuthenticationPrincipal.class);
     }
 
     @Override

--- a/src/main/java/com/example/backendmainserver/port/application/PortBatterySwitchService.java
+++ b/src/main/java/com/example/backendmainserver/port/application/PortBatterySwitchService.java
@@ -49,6 +49,10 @@ public class PortBatterySwitchService {
         }
 
         BatterySwitchRequest batterySwitchRequest = new BatterySwitchRequest(portAndSupplierList);
+        requestBatterySwitchToRaspberry(batterySwitchRequest);
+    }
+
+    public void requestBatterySwitchToRaspberry(BatterySwitchRequest batterySwitchRequest) {
         BatterySwitchResponse batterySwitchResponse =
                 raspberryClient.requestPortBatterySwitch(batterySwitchRequest);
 

--- a/src/main/java/com/example/backendmainserver/port/domain/PowerSupplier.java
+++ b/src/main/java/com/example/backendmainserver/port/domain/PowerSupplier.java
@@ -1,7 +1,7 @@
 package com.example.backendmainserver.port.domain;
 
 public enum PowerSupplier {
-    EXTERNAL("EXTERNAL"), BATTERY("BATTERY");
+    EXTERNAL("EXTERNAL"), BATTERY("BATTERY"), OFF("OFF");
 
     private final String name;
 

--- a/src/main/java/com/example/backendmainserver/port/presentation/PortController.java
+++ b/src/main/java/com/example/backendmainserver/port/presentation/PortController.java
@@ -1,0 +1,46 @@
+package com.example.backendmainserver.port.presentation;
+
+import com.example.backendmainserver.auth.presentation.AdminAuthenticationPrincipal;
+import com.example.backendmainserver.client.raspberry.dto.request.BatterySwitchRequest;
+import com.example.backendmainserver.client.raspberry.dto.request.PortAndSupplier;
+import com.example.backendmainserver.global.response.SuccessResponse;
+import com.example.backendmainserver.port.application.PortBatterySwitchService;
+import com.example.backendmainserver.port.application.PortService;
+import com.example.backendmainserver.port.presentation.dto.request.PortControlRequest;
+import com.example.backendmainserver.user.domain.User;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Tag(name = "Port API", description = "포트 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/port")
+public class PortController {
+    private final PortService portService;
+    private final PortBatterySwitchService portBatterySwitchService;
+
+    @PostMapping("/control")
+    public ResponseEntity<SuccessResponse<HttpStatus>> portControl(
+            @AdminAuthenticationPrincipal User user,
+            @RequestBody PortControlRequest portControlRequest){
+
+        BatterySwitchRequest batterySwitchRequest = convertToBatterySwitchRequest(portControlRequest);
+        portBatterySwitchService.requestBatterySwitchToRaspberry(batterySwitchRequest);
+
+        return SuccessResponse.of(HttpStatus.OK);
+    }
+
+    public BatterySwitchRequest convertToBatterySwitchRequest(PortControlRequest portControlRequest) {
+        List<PortAndSupplier> portAndSuppliers = portControlRequest.portIdAndStates().stream()
+                .map(portIdAndState -> new PortAndSupplier(portIdAndState.portId(), portIdAndState.state()))
+                .collect(Collectors.toList());
+
+        return new BatterySwitchRequest(portAndSuppliers);
+    }
+}

--- a/src/main/java/com/example/backendmainserver/port/presentation/PortController.java
+++ b/src/main/java/com/example/backendmainserver/port/presentation/PortController.java
@@ -6,8 +6,12 @@ import com.example.backendmainserver.client.raspberry.dto.request.PortAndSupplie
 import com.example.backendmainserver.global.response.SuccessResponse;
 import com.example.backendmainserver.port.application.PortBatterySwitchService;
 import com.example.backendmainserver.port.application.PortService;
+import com.example.backendmainserver.port.domain.Port;
 import com.example.backendmainserver.port.presentation.dto.request.PortControlRequest;
+import com.example.backendmainserver.port.presentation.dto.response.PortInfoResponse;
+import com.example.backendmainserver.port.presentation.dto.response.PortInfoResponses;
 import com.example.backendmainserver.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,6 +29,9 @@ public class PortController {
     private final PortService portService;
     private final PortBatterySwitchService portBatterySwitchService;
 
+    @Operation(summary = "포트 수동 제어 api", description =
+            "라즈베리파이에 연결된 포트의 전원을 제어합니다.\n" +
+            "state: BATTERY or EXTERNAL or OFF")
     @PostMapping("/control")
     public ResponseEntity<SuccessResponse<HttpStatus>> portControl(
             @AdminAuthenticationPrincipal User user,
@@ -34,6 +41,34 @@ public class PortController {
         portBatterySwitchService.requestBatterySwitchToRaspberry(batterySwitchRequest);
 
         return SuccessResponse.of(HttpStatus.OK);
+    }
+
+    @Operation(summary = "모든 포튼 정보 조회 List")
+    @GetMapping("")
+    public ResponseEntity<SuccessResponse<PortInfoResponses>> getAllPort(
+            @AdminAuthenticationPrincipal User user
+            ){
+
+        List<Port> ports = portService.getAllPorts();
+
+        List<PortInfoResponse> portInfoResponseList = convertToPortInfoResponseList(ports);
+
+
+        return SuccessResponse.of(new PortInfoResponses(portInfoResponseList));
+    }
+
+    private List<PortInfoResponse> convertToPortInfoResponseList(List<Port> ports) {
+        List<PortInfoResponse> list = ports.stream().map((p) -> {
+            return new PortInfoResponse(
+                    p.getId(),
+                    p.getMinimumOutput(),
+                    p.getMaximumOutput(),
+                    p.getRoom().getId(),
+                    p.getBatterySwitchOption(),
+                    p.getPowerSupplier().toString());
+        }).toList();
+
+        return list;
     }
 
     public BatterySwitchRequest convertToBatterySwitchRequest(PortControlRequest portControlRequest) {

--- a/src/main/java/com/example/backendmainserver/port/presentation/dto/request/PortControlRequest.java
+++ b/src/main/java/com/example/backendmainserver/port/presentation/dto/request/PortControlRequest.java
@@ -1,0 +1,6 @@
+package com.example.backendmainserver.port.presentation.dto.request;
+
+import java.util.List;
+
+public record PortControlRequest(List<PortIdAndState> portIdAndStates) {
+}

--- a/src/main/java/com/example/backendmainserver/port/presentation/dto/request/PortIdAndState.java
+++ b/src/main/java/com/example/backendmainserver/port/presentation/dto/request/PortIdAndState.java
@@ -1,0 +1,11 @@
+package com.example.backendmainserver.port.presentation.dto.request;
+
+/**
+ * id: portId를 의미
+ * state:
+ *  - BATTERY: 배터리로 공급
+ *  - EXTERNAL: 외부 전력으로 공급
+ *  - OFF: 전력 차단
+ */
+public record PortIdAndState(Long portId, String state) {
+}

--- a/src/main/java/com/example/backendmainserver/port/presentation/dto/response/PortInfoResponse.java
+++ b/src/main/java/com/example/backendmainserver/port/presentation/dto/response/PortInfoResponse.java
@@ -1,0 +1,11 @@
+package com.example.backendmainserver.port.presentation.dto.response;
+
+import com.example.backendmainserver.port.domain.BatterySwitchOption;
+
+public record PortInfoResponse(Long portId,
+                               Long minimumOutput,
+                               Long maximumOutput,
+                               Long roomId,
+                               BatterySwitchOption batterySwitchOption,
+                               String powerSupplier) {
+}

--- a/src/main/java/com/example/backendmainserver/port/presentation/dto/response/PortInfoResponses.java
+++ b/src/main/java/com/example/backendmainserver/port/presentation/dto/response/PortInfoResponses.java
@@ -1,0 +1,7 @@
+package com.example.backendmainserver.port.presentation.dto.response;
+
+import java.util.List;
+
+public record PortInfoResponses(List<PortInfoResponse> portInfoResponseList) {
+
+}


### PR DESCRIPTION
## 🔢 연관 이슈
#22 클라이언트(관리자)로 부터 데이터를 전달 받아 라즈베리파이 서버에 요청합니다. 

## 🔥 Task
- API end-point 제공
- 관리자의 요청만 허용
- 클라이언트의 요청을 라즈베리파이 Spring Server로 전달
- 모든 포트 조회 기능 제공
